### PR TITLE
G.node.iter() typo in The Graph data structures

### DIFF
--- a/I. The Graph Data Structures.ipynb
+++ b/I. The Graph Data Structures.ipynb
@@ -253,7 +253,7 @@
    },
    "outputs": [],
    "source": [
-    "for n in G.nodes_iter():\n",
+    "for n in G.nodes():\n",
     "    if type(n)== str:\n",
     "        print(n + ' is a string!')\n",
     "    else:\n",


### PR DESCRIPTION
I have chagned the G.nodes_iter() into G.nodes() and the code is working fine,

For reference working image,

https://github.com/bjedwards/NetworkXTutorial/issues/1#issue-2423602325